### PR TITLE
adding python requirements to run service-account-generate-keypair.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+argparse
+cryptography


### PR DESCRIPTION
Used for anyone following the Meossphere wiki and they want to use the service-account-generate-keypair.py